### PR TITLE
README.md: Corrected error in instructions to add service provider

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ composer require hedii/artisan-log-cleaner
 Add it to your providers array in `config/app.php`:
 
 ```php
-Hedii\ArtisanLogCleaner\ClearLogs::class
+Hedii\ArtisanLogCleaner\ArtisanLogCleanerServiceProvider::class
 ```
 
 ## Usage


### PR DESCRIPTION
This was super simple in the end. The readme.md was incorrectly instructing people to add the Command class to the providers array in `config/app.php`but it should have been the ServiceProvider class that they add. 